### PR TITLE
DATA-1196 Follow-up work.

### DIFF
--- a/lib/ResourceDataObjectElementsSetting.php
+++ b/lib/ResourceDataObjectElementsSetting.php
@@ -187,5 +187,44 @@ class ResourceDataObjectElementsSetting
         fclose($OUT);
     }
 
+    public function delete_taxon_if_no_dataObject($xml_string)
+    {
+        if($xml = simplexml_load_string($xml_string))
+        {
+            $i = 0;
+            foreach($xml->taxon as $taxon)
+            {
+                $i++;
+                $dc = $taxon->children("http://purl.org/dc/elements/1.1/");
+                $dwc = $taxon->children("http://rs.tdwg.org/dwc/dwcore/");
+                $dcterms = $taxon->children("http://purl.org/dc/terms/");
+                echo "\n " . $dc->identifier . " -- sciname: [" . $dwc->ScientificName ."]";
+                if(!$taxon->dataObject)
+                {
+                    echo " --- deleted \n";
+                    unset($dc->identifier);
+                    unset($dc->source);
+                    unset($dwc->Kingdom);
+                    unset($dwc->Phylum);
+                    unset($dwc->Class);
+                    unset($dwc->Order);
+                    unset($dwc->Family);
+                    unset($dwc->Genus);
+                    unset($dwc->ScientificName);
+                    unset($xml->taxon[$i-1]->commonName);
+                    unset($xml->taxon[$i-1]->synonym);
+                    unset($dcterms->created);
+                    unset($dcterms->modified);
+                    unset($xml->taxon[$i-1]->reference);
+                    unset($xml->taxon[$i-1]->dataObject);
+                }
+            }
+            $xml_string = $xml->asXML();
+            $xml_string = preg_replace('/\s*(<[^>]*>)\s*/', '$1', $xml_string); // remove whitespaces
+            $xml_string = str_ireplace(array("<taxon></taxon>", "<taxon/>"), "", $xml_string);
+            return $xml_string;
+        }
+    }
+
 }
 ?>

--- a/lib/connectors/WormsAPI.php
+++ b/lib/connectors/WormsAPI.php
@@ -91,7 +91,7 @@ class WormsAPI
                 $task = str_ireplace("\n", "", $task);//remove carriage return got from text file
                 if($call_multiple_instance) //call 2 other instances for a total of 3 instances running
                 {
-                    Functions::run_another_connector_instance($resource_id, 2);
+                    Functions::run_another_connector_instance($resource_id, 4);
                     $call_multiple_instance = 0;
                 }
                 self::get_all_taxa($task);
@@ -151,18 +151,21 @@ class WormsAPI
         $timestart = time_elapsed(); echo "\n start timer";
         $file = WORMS_TAXON_API . $id;
         echo "$file\n";
-        if($contents = Functions::get_remote_file($file, DOWNLOAD_WAIT_TIME, 240, 5))
+        if($contents = Functions::get_remote_file($file, DOWNLOAD_WAIT_TIME, 600, 5))
         {
-            $pos1 = stripos($contents, "<taxon>");
-            $pos2 = stripos($contents, "</taxon>");
-            if($pos1 != "" and $pos2 != "")
+            if(simplexml_load_string($contents))
             {
-                $contents = trim(substr($contents, $pos1, $pos2 - $pos1 + 8));
-                $elapsed_time_sec = time_elapsed() - $timestart;
-                echo "\n";
-                echo "elapsed time = " . $elapsed_time_sec . " seconds \n";
-                $this->exec_time_in_seconds += $elapsed_time_sec;
-                return $contents;
+                $pos1 = stripos($contents, "<taxon>");
+                $pos2 = stripos($contents, "</taxon>");
+                if($pos1 != "" and $pos2 != "")
+                {
+                    $contents = trim(substr($contents, $pos1, $pos2 - $pos1 + 8));
+                    $elapsed_time_sec = time_elapsed() - $timestart;
+                    echo "\n";
+                    echo "elapsed time = " . $elapsed_time_sec . " seconds \n";
+                    $this->exec_time_in_seconds += $elapsed_time_sec;
+                    return $contents;
+                }
             }
         }
         @$GLOBALS['WORMS_bad_id'] .= $id . ",";
@@ -248,7 +251,9 @@ class WormsAPI
         $r[] = $ids[9];
         $ids = $r;
         */
-
+        
+        // $ids = array(); $ids[] = 246718;//9182;//243944;
+        
         /*debug: to be used when searching for an id
         foreach(array(582008, 582009, 582010) as $id)
         {

--- a/update_resources/connectors/26.php
+++ b/update_resources/connectors/26.php
@@ -28,4 +28,28 @@ Soon this connector will be obsolete as WORMS agreed to provide a DWC-A resource
 // echo "elapsed time = " . $elapsed_time_sec/60/60/24 . " days \n";
 // echo date('Y-m-d h:i:s a', time())."\n";
 // echo "\n\n Done processing.";
+
+
+function worms_check()
+{
+    $path = "http://localhost/~eolit/eli/eol_php_code/applications/content_server/resources/26.xml";
+    print "\n xml file: [$path] \n";
+    $reader = new \XMLReader();
+    $reader->open($path);
+    $i = 0;
+    while(@$reader->read())
+    {
+        if($reader->nodeType == \XMLReader::ELEMENT && $reader->name == "taxon")
+        {
+            $string = $reader->readOuterXML();
+            if($xml = simplexml_load_string($string)) print " ok ";
+            else 
+            {
+                print " bad "; $i++;
+            }
+        }
+    }
+    print "\n\n invalid xml: $i";
+}
+
 ?>

--- a/update_resources/connectors/544.php
+++ b/update_resources/connectors/544.php
@@ -41,6 +41,7 @@ fclose($resource_file);
 rename(CONTENT_RESOURCE_LOCAL_PATH . $resource_id . "_temp.xml", CONTENT_RESOURCE_LOCAL_PATH . $resource_id . ".xml");
 
 Functions::set_resource_status_to_force_harvest($resource_id);
+remove_bhl_images_already_existing_in_eol_group($resource_id);
 
 $elapsed_time_sec = time_elapsed() - $timestart;
 echo "\n";
@@ -48,5 +49,106 @@ echo "elapsed time = $elapsed_time_sec seconds             \n";
 echo "elapsed time = " . $elapsed_time_sec/60 . " minutes  \n";
 echo "elapsed time = " . $elapsed_time_sec/60/60 . " hours \n";
 echo "\n\n Done processing.";
+
+
+function remove_bhl_images_already_existing_in_eol_group($resource_id)
+{
+    $file = "http://dl.dropbox.com/u/7597512/BHL_images/BHL_images_in_EOLGroup.txt";
+    // $file = "http://localhost/~eolit/eli/eol_php_code/update_resources/connectors/files/BHL_images/BHL_images_in_EOLGroup_sample.txt";
+    $contents = Functions::get_remote_file($file, DOWNLOAD_WAIT_TIME, 600, 5);
+    $do_ids = json_decode($contents,true);
+    print "\n\n from text file: " . count($do_ids);
+    $resource_path = CONTENT_RESOURCE_LOCAL_PATH . $resource_id . ".xml";
+    $xml_string = Functions::get_remote_file($resource_path, DOWNLOAD_WAIT_TIME, 240, 5);
+    $xml = simplexml_load_string($xml_string);
+    $i = 0;
+    $deleted_ids = array();
+    $deleted = 0;
+    foreach($xml->taxon as $taxon)
+    {
+        $i++;
+        $dwc = $taxon->children("http://rs.tdwg.org/dwc/dwcore/");
+        echo "\n[" . $dwc->ScientificName."]";
+        $j = 0;
+        $deleted_do_keys = array();
+        foreach($taxon->dataObject as $do)
+        {
+            $j++;
+            $dc2 = $do->children("http://purl.org/dc/elements/1.1/");
+            $do_id = trim($dc2->identifier);
+            if(in_array($do_id, $do_ids))
+            {
+                $deleted++;
+                $deleted_ids[$do_id] = 1;
+                print "\n --- deleting $do_id";
+                $deleted_do_keys[] = $j-1;
+            }
+        }
+        foreach($deleted_do_keys as $key)
+        {
+            unset($xml->taxon[$i-1]->dataObject[$key]);
+        }
+    }
+    print "\n\n occurrence do_ids: $i";
+    print "\n\n deleted <dataObject>s: $deleted";
+    print "\n\n deleted unique do_ids: " . count($deleted_ids);
+    $xml_string = $xml->asXML();
+    require_library('ResourceDataObjectElementsSetting');
+    $xml_string = ResourceDataObjectElementsSetting::delete_taxon_if_no_dataObject($xml_string);
+    $WRITE = fopen($resource_path, "w");
+    fwrite($WRITE, $xml_string);
+    fclose($WRITE);
+}
+
+function bhl_image_count() // just for stats
+{
+    $path = "http://localhost/~eolit/eli/eol_php_code/applications/content_server/resources/544.xml";
+    $path = "http://localhost/~eolit/eli/eol_php_code/applications/content_server/resources/544%20BHL%20in%20EOL%20Flickr%20Group.xml";
+    print "\n xml file: [$path] \n";
+    $reader = new \XMLReader();
+    $reader->open($path);
+    $i = 0;
+    $do_ids = array();
+    $names = array();
+    while(@$reader->read())
+    {
+        if($reader->nodeType == \XMLReader::ELEMENT && $reader->name == "taxon")
+        {
+            $string = $reader->readOuterXML();
+            $taxon = simplexml_load_string($string);
+            $t_dc = $taxon->children("http://purl.org/dc/elements/1.1/");
+            $t_dwc = $taxon->children("http://rs.tdwg.org/dwc/dwcore/");
+            $family         = trim($t_dwc->Family);
+            $genus          = trim($t_dwc->Genus);
+            $scientificname = trim($t_dwc->ScientificName);
+            $taxon_identifier = trim($t_dc->identifier);
+            $i++;
+            print "\n $i. $scientificname [$taxon_identifier]";
+            $names[$scientificname] = 1;
+            foreach($taxon->dataObject as $do)
+            {
+                $t_dc2 = $do->children("http://purl.org/dc/elements/1.1/");
+                $id = trim($t_dc2->identifier);
+                $do_ids[$id] = 1;
+            }
+        }
+    }
+    $names = array_keys($names);
+    print "\n total names: " . count($names);
+    $do_ids = array_keys($do_ids);
+    print "\n total do: " . count($do_ids);
+    
+    $filename = "BHL_images_in_EOLGroup.txt";
+    $WRITE = fopen($filename, "w");
+    fwrite($WRITE, json_encode($do_ids));
+    fclose($WRITE);
+
+    // just testing - reading it back
+    $READ = fopen($filename, "r");
+    $contents = fread($READ, filesize($filename));
+    fclose($READ);
+    $do_ids = json_decode($contents,true);
+    print "\n\n from text file: " . count($do_ids);
+}
 
 ?>


### PR DESCRIPTION
DATA-1196 Follow-up work. Now connector only harvests those images from BHL photo stream that are not already on EOL. Some WORMS connector maintenance.
