### PR TITLE
iNaturalist / Flickr deduplication - groundwork

### DIFF
--- a/lib/ArchiveDataIngester.php
+++ b/lib/ArchiveDataIngester.php
@@ -398,7 +398,7 @@ class ArchiveDataIngester
         }
         
         if(!$object_taxon_info) return false;
-        if($this->harvest_event->resource->is_inaturalist() && isset($original_flickr_img = self::image_in_flickr($row))) {
+        if($this->harvest_event->resource->is_inaturalist() && (!is_null($original_flickr_img = self::image_in_flickr($row)))) {
 	        //here we could update $original_flickr_img, replace it with the iNat one, or whatever
         	return false;
         }


### PR DESCRIPTION
This simply changes the is_this_image_in_flickr() function to return data about the flickr image, if it exists. The function name is also changed to image_in_flickr() to reflect this.

These changes leave the behaviour of the code completely unaltered for the moment. But it should allow future alterations which carry out a more sensible deduplication effort (see http://eol.org/forums/11/topics/28).
