### PR TITLE
Set mimeType correctly for Wikimedia Commons images

### DIFF
--- a/vendor/wikipedia/WikimediaPage.php
+++ b/vendor/wikipedia/WikimediaPage.php
@@ -233,6 +233,7 @@ class WikimediaPage
         # so I'm just adding up the ascii values of the strings and appending that to the identifier
         $data_object_parameters["identifier"] .= "_" . array_sum(array_map('ord', str_split($data_object_parameters["identifier"])));
         $data_object_parameters["dataType"] = "http://purl.org/dc/dcmitype/StillImage";
+        $data_object_parameters["mimeType"] = Functions::get_mimetype($this->title);
         $data_object_parameters["title"] = $this->title;
         $data_object_parameters["source"] = "http://commons.wikimedia.org/wiki/".str_replace(" ", "_", $this->title);
         $data_object_parameters["description"] = $this->description();


### PR DESCRIPTION
Simply adds the mimeType to images harvested from Wikimedia Commons. Currently this seems to default to image/jpeg for all images - but I have no idea where the default jpeg value is coming from. It is not specified in WikimediaPage.php or the connector, eol_php_code / update_resources / connectors / 71.php.

Hopefully the mimeType set by the code in this pull request will not be overwritten somewhere else in the code by a default "image/jpeg" mime type.
