### PR TITLE
Deduce mimeType for non-text files obtained through USDA connector

### DIFF
--- a/update_resources/connectors/108.php
+++ b/update_resources/connectors/108.php
@@ -360,16 +360,15 @@ function get_data_object($id, $description, $dc_rights, $title, $url, $subject, 
         $dataObjectParameters["dataType"] = "http://purl.org/dc/dcmitype/Text";
         $dataObjectParameters["mimeType"] = "text/html";
     }
-    /*
     else
     {
-        $dataObjectParameters["identifier"] = $id;
-        $dataObjectParameters["dataType"] = "http://purl.org/dc/dcmitype/StillImage";
-
-        $dataObjectParameters["mimeType"] = "image/jpeg";
-        $dataObjectParameters["mediaURL"] = $mediaurl;
+        //$dataObjectParameters["identifier"] = $id;
+        //$dataObjectParameters["dataType"] = "http://purl.org/dc/dcmitype/StillImage";
+        
+        $dataObjectParameters["mimeType"] = Functions::get_mimetype($url);
+        //$dataObjectParameters["mediaURL"] = $mediaurl;
     }
-    */
+    
             /////////////////////////////////////////////////////////////
 
             foreach ($arr_agents as $g)


### PR DESCRIPTION
There are some tiff files coming through this connector which are mistakenly labelled as mimeType: image/jpg (e.g. http://eol.org/api/data_objects/1.0/1386367.json). This code change may correct that.

I am unsure why the current code has lines 363-371 commented out, though.
