### PR TITLE
Allow a "SchemaDocument" object to be created, which can be written to ...

### DIFF
--- a/vendor/eol_content_schema/SchemaDocument.php
+++ b/vendor/eol_content_schema/SchemaDocument.php
@@ -2,6 +2,36 @@
 
 class SchemaDocument
 {
+    private $FILE;
+    
+    function __construct($filename, $fopen_flags="w+") {
+        $this->FILE = fopen($filename, $fopen_flags);
+        if ($this->FILE === FALSE) {
+            echo "Could not open file $filename\n";
+            flush();
+            return FALSE;
+        }
+        fwrite($this->FILE, self::xml_header());
+    }
+    
+    public function save_taxon_xml($t) {
+        if ($this->FILE === FALSE) {
+            echo "Could not write to file, as it is not open\n";
+            flush();
+            return FALSE;
+        }
+        fwrite($this->FILE, $t->__toXML());
+    }
+    
+    function __destruct() {
+        if ($this->FILE === FALSE) {
+            echo "Could not close file.\n";
+            flush();
+        } 
+        fwrite($this->FILE, self::xml_footer());
+        fclose($this->FILE);
+    }
+    
     public static function print_taxon_xml($taxa)
     {
         header('Content-type: text/xml');


### PR DESCRIPTION
incrementally, using save_taxon_xml().

The XML footer is written when object is destroyed.

This will be used for the new wikimedia harvester.
