### PR TITLE
Save Flickr rotation info in the "additionalInformation" field of the da...

### DIFF
--- a/app/models/DataObjects.php
+++ b/app/models/DataObjects.php
@@ -205,10 +205,19 @@ class DataObject extends ActiveRecord
         {
             if(preg_match("/^http:\/\//",$this->object_url) || preg_match("/^https:\/\//",$this->object_url))
             {
-                // TODO - hardcoded exception to make the Biopix images smaller
-                $thumbnail_options = array();
-                if($resource->title == "Biopix") $thumbnail_options = array('large_image_dimensions' => array(300, 300));
-                $this->object_cache_url = $content_manager->grab_file($this->object_url, 0, "image", $thumbnail_options);
+                // Hardcoded exception to make the Biopix images smaller
+                $image_options = array();
+                if($resource->title == "Biopix") $image_options['large_image_dimensions'] = array(300, 300);
+                if(isset($resource->flickr()))
+                {
+                    if (isset($this->additionalInformation)) //I'm not sure this is the correct way to access the 'additionalInformation' data object field
+                    {
+                        if (preg_match("/<rotation>(\d+)</rotation>/", $this->additionalInformation, $arr) {
+                            $image_options['rotation'] = $arr[1];
+                        }
+                    }
+                }
+                $this->object_cache_url = $content_manager->grab_file($this->object_url, 0, "image", $image_options);
                 if(@!$this->object_cache_url) return false;
             }else return false;
         }

--- a/lib/ContentManager.php
+++ b/lib/ContentManager.php
@@ -324,7 +324,7 @@ class ContentManager
 
     function create_content_thumbnails($file, $prefix, $options = array())
     {
-        $this->reduce_original($file, $prefix);
+        $this->reduce_original($file, $prefix, @($options['rotation']));
         // we make an exception
         if(isset($options['large_image_dimensions']) && is_array($options['large_image_dimensions']))
         {
@@ -344,9 +344,15 @@ class ContentManager
         $this->create_constrained_square_crop($file, ContentManager::small_square_dimensions(), $prefix);
     }
 
-    function reduce_original($path, $prefix)
+    function reduce_original($path, $prefix, $rotation=null)
     {
-        $command = CONVERT_BIN_PATH." $path -strip -background white -flatten -auto-orient -quality 80";
+        if (isset($rotation))
+        {
+            $rotate = "-rotate $rotation";
+        } else {
+            $rotate = "-auto-orient";
+        } 
+        $command = CONVERT_BIN_PATH." $path -strip -background white -flatten $rotate -quality 80";
         $new_image_path = $prefix."_orig.jpg";
         shell_exec($command." ".$new_image_path);
         self::create_checksum($new_image_path);

--- a/lib/FlickrAPI.php
+++ b/lib/FlickrAPI.php
@@ -238,6 +238,7 @@ class FlickrAPI
         $data_object_parameters["license"] = @$GLOBALS["flickr_licenses"][$photo->license];
         $data_object_parameters["language"] = 'en';
         if(isset($photo->dates->taken)) $data_object_parameters["created"] = $photo->dates->taken;
+        if(isset($photo->rotation)) $data_object_parameters["additionalInformation"] = '<rotation>'.$photo->rotation.'</rotation>';
         
         foreach($photo->urls->url as $url)
         {


### PR DESCRIPTION
...taObject, then pass it in to grab_file so that the image can be correctly rotated when harvesting.

This will help with a number of flickr images that have been rotated by hand in Flickr (many BHL images).

The flickr "rotation" parameter includes any rotations specified in the EXIF metadata, so if we have a Flickr rotation value, we should override the EXIF rotation specification.

I'm unsure of the correct way to access the additionalInformation field from within the DataObjects class - a comment is inserted as appropriate. This will probably need changing.
