### PR TITLE
Wikiparser preg bugfix

### DIFF
--- a/vendor/wikipedia/WikiParser.php
+++ b/vendor/wikipedia/WikiParser.php
@@ -200,8 +200,11 @@ class WikiParser
 
     public static function strip_tags($string)
     {
-        $string = preg_replace("/<(.*?)>(.*?)<\/\\1>/us", "\\2", $string);
-
+        do {
+            $string = preg_replace("/<(\w*?)[^>]*>(.*?)<\/\\1>/us", "\\2", $string, -1, $count);
+        } while ($count); //allow for nested tags
+        $string = preg_replace("/<br(\s\/)?>/us", "", $string); // tags that don't need closing
+        
         return $string;
     }
 


### PR DESCRIPTION
Corrects a long-standing bug in wikitext parsing, which leads to an infinite loop. This should probably be ported to the master branch as well as the wikimedia_improvements branch. Presumably we have not got bitten by it previously as the old code was ignoring many description fields.
