### PR TITLE
Audio spectrogram thumbnails

### DIFF
--- a/lib/ContentManager.php
+++ b/lib/ContentManager.php
@@ -77,7 +77,7 @@ class ContentManager
             // create thumbnails of website content and agent logos
             switch($type) {
                 case "image":
-                    $this->create_content_thumbnails($new_file_path, $new_file_prefix, $options);
+                    $this->create_image_thumbnails($new_file_path, $new_file_prefix, $options);
                     break;
                 case "partner":
                     $this->create_agent_thumbnails($new_file_path, $new_file_prefix);
@@ -365,7 +365,7 @@ class ContentManager
         return $dimensions;
     }
 
-    function create_content_thumbnails($file, $prefix, $options = array())
+    function create_image_thumbnails($file, $prefix, $options = array())
     {
         $local_file = $this->reduce_original($file, $prefix, $options);
         // we make an exception

--- a/lib/ContentManager.php
+++ b/lib/ContentManager.php
@@ -79,6 +79,14 @@ class ContentManager
                 case "image":
                     $this->create_image_thumbnails($new_file_path, $new_file_prefix, $options);
                     break;
+                case "audio":
+                    /* Some audio, video, etc files may have thumbnails created from the harvesting site (code in DataObjects.php).
+                       This could be a picture, a spectrogram, or whatever. Here we create a default thumbnail set for audio files. 
+                       Those that already have a thumbnail will thus have 2 potential sets of thumbnails. The "default" ones created
+                        here are guaranteed to have the same prefix as the audio (.wav, .mp3 etc) file, but are .png files */
+                    $this->create_audio_thumbnails($new_file_path, $new_file_prefix, $options);
+                    break;
+
                 case "partner":
                     $this->create_agent_thumbnails($new_file_path, $new_file_prefix);
                     break;
@@ -335,6 +343,7 @@ class ContentManager
         return $new_suffix;
     }
 
+    //max dimensions for the various sizes of thumbnail images, expressed as (width, height)
     static function large_image_dimensions()
     {
         static $dimensions = array(580, 360);
@@ -379,6 +388,24 @@ class ContentManager
         if(isset($options['crop_width'])) $image_path = $prefix . '_orig.jpg';
         $this->create_upper_left_crop($image_path, self::large_square_dimensions(), $prefix, $options);
         $this->create_upper_left_crop($image_path, self::small_square_dimensions(), $prefix, $options);
+    }
+
+    function create_audio_thumbnails($audiofile, $prefix, $options = array())
+    {
+        
+        //Create "XXX_orig.png" spectrogram, whose width varies with length of sound file (with maximum length constraint)
+        $truncate_after_seconds = 60;
+        $pixels_per_second = 50;
+        $dimensions = array($pixels_per_second, self::large_image_dimensions()[1]);
+        $this->create_spectrogram($audiofile, $dimensions, $prefix, $truncate_after_seconds, true, "orig", false);
+
+        //Fixed width spectrogram thumbnails, omit axes for smaller sizes 
+        $truncate_after_seconds = 30;
+        $this->create_spectrogram($audiofile, self::large_image_dimensions(), $prefix, $truncate_after_seconds, true);
+        $this->create_spectrogram($audiofile, self::medium_image_dimensions(), $prefix, $truncate_after_seconds, true);
+        $this->create_spectrogram($audiofile, self::small_image_dimensions(), $prefix, $truncate_after_seconds, false);
+        $this->create_spectrogram($audiofile, self::large_square_dimensions(), $prefix, $truncate_after_seconds, false);
+        $this->create_spectrogram($audiofile, self::small_square_dimensions(), $prefix, $truncate_after_seconds, false);
     }
 
     function create_agent_thumbnails($file, $prefix)
@@ -463,6 +490,57 @@ class ContentManager
         self::create_checksum($new_image_path);
         return $new_image_path;
     }
+
+    function create_spectrogram($audiofile, $dimensions, $prefix, $max_seconds, $show_axes, $suffix=null, $fixed_width=true)
+    {
+        if (defined('SOX_BIN_PATH')) {
+            if (is_null($suffix))
+                $suffix = implode($dimensions, '_');
+            $spectrogram_path = $prefix."_".$suffix.".png";
+
+            // by trial and error, axis labels etc in SoX spectrograms seem to take 144 px in the X direction and 78 in the Y
+            $axis_decoration_px = array(144, 78);
+            $x = $dimensions[0];
+            $y = $dimensions[1];
+            //limit max dB, force white background, simple colour scheme, etc. see http://sox.sourceforge.net/sox.html
+            $sox_options = "--null remix - trim 0 $max_seconds norm spectrogram -z 50 -p 1 -l  -c ''";
+            if ($show_axes) {
+                $y -= $axis_decoration_px[1];
+                if ($fixed_width)
+                    $x -= $axis_decoration_px[0];
+            } else {
+                $sox_options .= " -r";
+            }
+            
+            if ($fixed_width)
+            {
+                //SoX only accepts x > 100px: if less, make a larger image and post-process to resize it down. 
+                if ($x < 100)
+                {
+                    $x = 100;
+                    $post_processing = CONVERT_BIN_PATH." ".escapeshellarg($spectrogram_path)." -resize ".$dimensions[0]."x".$dimensions[1]."! ".escapeshellarg($spectrogram_path);
+                }
+                $sox_options .= " -x $x -y $y";
+            } else {
+                //if not fixed_width, first element of $dimensions gives pixels per second
+                $sox_options .= " -X $x -y $y";
+            }
+
+            $command = SOX_BIN_PATH." -V0 ".escapeshellarg($audiofile)." $sox_options";
+            shell_exec($command." -o ".escapeshellarg($spectrogram_path));
+            //if sox does not exist, or cannot create the spectrograph, the spectrogram file should not exist
+            if (file_exists($spectrogram_path)) {
+                if (isset($post_processing))
+                    shell_exec($post_processing);
+                self::create_checksum($spectrogram_path);
+                return $spectrogram_path;
+            } else {
+                trigger_error("ContentManager: SoX could not produce thumbnail spectrogram for audio file $audiofile", E_USER_NOTICE);
+            }
+        }
+        return null;
+    }    
+
 
     function new_resource_file_name($resource_id)
     {

--- a/lib/ContentManager.php
+++ b/lib/ContentManager.php
@@ -75,26 +75,36 @@ class ContentManager
             }
 
             // create thumbnails of website content and agent logos
-            if($type=="image") $this->create_content_thumbnails($new_file_path, $new_file_prefix, $options);
-            elseif($type=="partner") $this->create_agent_thumbnails($new_file_path, $new_file_prefix);
-            elseif($type=="dataset")
-            {
-                $new_file_path = $this->zip_file($new_file_path);
-                $this->delete_old_datasets();
+            switch($type) {
+                case "image":
+                    $this->create_content_thumbnails($new_file_path, $new_file_prefix, $options);
+                    break;
+                case "partner":
+                    $this->create_agent_thumbnails($new_file_path, $new_file_prefix);
+                    break;
             }
-
-            if(in_array($type, array("image", "video", "audio", "upload", "partner"))) self::create_checksum($new_file_path);
 
             // Take the substring of the new file path to return via the webservice
-            if(($type=="image" || $type=="video" || $type=="audio" || $type=="partner" || $type=="upload") &&
-              preg_match("/^".preg_quote(CONTENT_LOCAL_PATH, "/")."(.*)\.[^\.]+$/", $new_file_path, $arr))
-            {
-                $new_file_path = str_replace("/", "", $arr[1]);
-            }
-            elseif($type=="resource" &&
-              preg_match("/^".preg_quote(CONTENT_RESOURCE_LOCAL_PATH, "/")."(.*)$/", $new_file_path, $arr))  $new_file_path = $arr[1];
-            elseif($type=="dataset" &&
-              preg_match("/^".preg_quote(CONTENT_DATASET_PATH, "/")."(.*)$/", $new_file_path, $arr))  $new_file_path = $arr[1];
+            switch($type) {
+                case "image":
+                case "video":
+                case "audio":
+                case "upload":
+                case "partner":
+                    self::create_checksum($new_file_path);
+                    if (preg_match("/^".preg_quote(CONTENT_LOCAL_PATH, "/")."(.*)\.[^\.]+$/", $new_file_path, $arr))
+                        $new_file_path = str_replace("/", "", $arr[1]);
+                    break;
+                case "resource":
+                    if (preg_match("/^".preg_quote(CONTENT_RESOURCE_LOCAL_PATH, "/")."(.*)$/", $new_file_path, $arr))
+                        $new_file_path = $arr[1];
+                    break;
+                case "dataset":
+                    $new_file_path = $this->zip_file($new_file_path);
+                    $this->delete_old_datasets();
+                    if (preg_match("/^".preg_quote(CONTENT_DATASET_PATH, "/")."(.*)$/", $new_file_path, $arr))
+                        $new_file_path = $arr[1];
+            }              
         }
 
         if(file_exists($temp_file_path)) unlink($temp_file_path);

--- a/lib/ContentManager.php
+++ b/lib/ContentManager.php
@@ -395,7 +395,7 @@ class ContentManager
         
         //Create "XXX_orig.png" spectrogram, whose width varies with length of sound file (with maximum length constraint)
         $truncate_after_seconds = 60;
-        $pixels_per_second = 50;
+        $pixels_per_second = 100;
         $dimensions = array($pixels_per_second, self::large_image_dimensions()[1]);
         $this->create_spectrogram($audiofile, $dimensions, $prefix, $truncate_after_seconds, true, "orig", false);
 

--- a/lib/ContentManager.php
+++ b/lib/ContentManager.php
@@ -172,7 +172,7 @@ class ContentManager
                 }
                 if(preg_match("/^(.*)\.(gz|gzip)$/", $new_temp_file_path, $arr))
                 {
-                    shell_exec(GUNZIP_BIN_PATH . " -f $new_temp_file_path");
+                    shell_exec(GUNZIP_BIN_PATH . " -f ".escapeshellarg($new_temp_file_path));
                     $new_temp_file_path = $arr[1];
                     return self::give_temp_file_right_extension($new_temp_file_path, $original_suffix, $unique_key);
                     self::move_up_if_only_directory($new_temp_file_path);
@@ -184,7 +184,7 @@ class ContentManager
                     @rmdir($archive_directory);
                     mkdir($archive_directory);
 
-                    shell_exec(TAR_BIN_PATH . " -xf $new_temp_file_path -C $archive_directory");
+                    shell_exec(TAR_BIN_PATH . " -xf ".escapeshellarg($new_temp_file_path)." -C ".escapeshellarg($archive_directory));
                     if(file_exists($new_temp_file_path)) unlink($new_temp_file_path);
                     $new_temp_file_path = $archive_directory;
                     self::move_up_if_only_directory($new_temp_file_path);
@@ -196,7 +196,7 @@ class ContentManager
                     @rmdir($archive_directory);
                     mkdir($archive_directory);
 
-                    shell_exec(UNZIP_BIN_PATH . " -d $archive_directory $new_temp_file_path");
+                    shell_exec(UNZIP_BIN_PATH . " -d ".escapeshellarg($archive_directory)." ".escapeshellarg($new_temp_file_path));
                     if(file_exists($new_temp_file_path)) unlink($new_temp_file_path);
                     $new_temp_file_path = $archive_directory;
                     self::move_up_if_only_directory($new_temp_file_path);
@@ -228,7 +228,7 @@ class ContentManager
     public static function determine_file_suffix($file_path, $suffix)
     {
         // use the Unix/Linux `file` command to determine file type
-        $stat = strtolower(shell_exec(FILE_BIN_PATH . " " . $file_path));
+        $stat = strtolower(shell_exec(FILE_BIN_PATH . " " . escapeshellarg($file_path)));
         $file_type = "";
         if(preg_match("/^[^ ]+: (.*)$/",$stat,$arr)) $file_type = trim($arr[1]);
         if(preg_match("/^\"(.*)/", $file_type, $arr)) $file_type = trim($arr[1]);
@@ -391,9 +391,9 @@ class ContentManager
     {
         $rotate = "-auto-orient";
         if(isset($options['rotation'])) $rotate = "-rotate ". intval($options['rotation']);
-        $command = CONVERT_BIN_PATH." $path -strip -background white -flatten $rotate -quiet -quality 80";
+        $command = CONVERT_BIN_PATH." ".escapeshellarg($path)." -strip -background white -flatten $rotate -quiet -quality 80";
         $new_image_path = $prefix."_orig.jpg";
-        shell_exec($command." ".$new_image_path);
+        shell_exec($command." ".escapeshellarg($new_image_path));
         self::create_checksum($new_image_path);
         return $new_image_path;
     }
@@ -401,10 +401,10 @@ class ContentManager
     function create_smaller_version($path, $dimensions, $prefix, $suffix)
     {
         //don't need to rotate, as this works on already-rotated version
-        $command = CONVERT_BIN_PATH." $path -strip -background white -flatten -quiet -quality 80 \
+        $command = CONVERT_BIN_PATH." ".escapeshellarg($path)." -strip -background white -flatten -quiet -quality 80 \
                         -resize ".$dimensions[0]."x".$dimensions[1]."\">\"";
         $new_image_path = $prefix ."_". $suffix .".jpg";
-        shell_exec($command." ".$new_image_path);
+        shell_exec($command." ".escapeshellarg($new_image_path));
         self::create_checksum($new_image_path);
         return $new_image_path;
     }
@@ -436,30 +436,30 @@ class ContentManager
                 $new_x_offset = floatval($options['x_offset']) * $offset_factor;
                 $new_y_offset = floatval($options['y_offset']) * $offset_factor;
 
-                $command = CONVERT_BIN_PATH. " $path -strip -background white -flatten -quiet -quality 80 -gravity NorthWest \
+                $command = CONVERT_BIN_PATH." ".escapeshellarg($path)." -strip -background white -flatten -quiet -quality 80 -gravity NorthWest \
                         -crop ".$new_crop_width."x".$new_crop_width."+".$new_x_offset."+".$new_y_offset." +repage \
                         -resize ".$dimensions[0]."x".$dimensions[0];
             }
         }else
         {
             // default command just makes the image square by cropping the edges: see http://www.imagemagick.org/Usage/resize/#fill
-            $command = CONVERT_BIN_PATH. " $path -strip -background white -flatten -quiet -quality 80 \
+            $command = CONVERT_BIN_PATH. " ".escapeshellarg($path)." -strip -background white -flatten -quiet -quality 80 \
                             -resize ".$dimensions[0]."x".$dimensions[0]."^ \
                             -gravity NorthWest -crop ".$dimensions[0]."x".$dimensions[0]."+0+0 +repage";
         }
         $new_image_path = $prefix ."_". $dimensions[0] ."_". $dimensions[0] .".jpg";
-        shell_exec($command." ".$new_image_path);
+        shell_exec($command." ".escapeshellarg($new_image_path));
         self::create_checksum($new_image_path);
     }
 
     function create_constrained_square_crop($path, $dimensions, $prefix)
     {
         // requires "convert" to support -gravity center -extent: ImageMagick >= 6.3.2
-        $command = CONVERT_BIN_PATH." $path -strip -background white -flatten -auto-orient -quiet -quality 80 \
+        $command = CONVERT_BIN_PATH." ".escapeshellarg($path)." -strip -background white -flatten -auto-orient -quiet -quality 80 \
                         -resize '".$dimensions[0]."x".$dimensions[0]."' -gravity center \
                         -extent '".$dimensions[0]."x".$dimensions[0]."' +repage";
         $new_image_path = $prefix."_".$dimensions[0]."_".$dimensions[0].".jpg";
-        shell_exec($command." ".$new_image_path);
+        shell_exec($command." ".escapeshellarg($new_image_path));
         self::create_checksum($new_image_path);
         return $new_image_path;
     }

--- a/lib/ContentManager.php
+++ b/lib/ContentManager.php
@@ -372,19 +372,19 @@ class ContentManager
         if(isset($options['large_image_dimensions']) && is_array($options['large_image_dimensions']))
         {
             $large_image_dimensions = $options['large_image_dimensions'];
-        }else $large_image_dimensions = ContentManager::large_image_dimensions();
-        $image_path = $this->create_smaller_version($local_file, $large_image_dimensions, $prefix, implode(ContentManager::large_image_dimensions(), '_'));
-        $this->create_smaller_version($image_path, ContentManager::medium_image_dimensions(), $prefix, implode(ContentManager::medium_image_dimensions(), '_'));
-        $this->create_smaller_version($image_path, ContentManager::small_image_dimensions(), $prefix, implode(ContentManager::small_image_dimensions(), '_'));
+        }else $large_image_dimensions = self::large_image_dimensions();
+        $image_path = $this->create_smaller_version($local_file, $large_image_dimensions, $prefix, implode(self::large_image_dimensions(), '_'));
+        $this->create_smaller_version($image_path, self::medium_image_dimensions(), $prefix, implode(self::medium_image_dimensions(), '_'));
+        $this->create_smaller_version($image_path, self::small_image_dimensions(), $prefix, implode(self::small_image_dimensions(), '_'));
         if(isset($options['crop_width'])) $image_path = $prefix . '_orig.jpg';
-        $this->create_upper_left_crop($image_path, ContentManager::large_square_dimensions(), $prefix, $options);
-        $this->create_upper_left_crop($image_path, ContentManager::small_square_dimensions(), $prefix, $options);
+        $this->create_upper_left_crop($image_path, self::large_square_dimensions(), $prefix, $options);
+        $this->create_upper_left_crop($image_path, self::small_square_dimensions(), $prefix, $options);
     }
 
     function create_agent_thumbnails($file, $prefix)
     {
-        $this->create_constrained_square_crop($file, ContentManager::large_square_dimensions(), $prefix);
-        $this->create_constrained_square_crop($file, ContentManager::small_square_dimensions(), $prefix);
+        $this->create_constrained_square_crop($file, self::large_square_dimensions(), $prefix);
+        $this->create_constrained_square_crop($file, self::small_square_dimensions(), $prefix);
     }
 
     function reduce_original($path, $prefix, $options = array())

--- a/tests/unit/test_content_manager.php
+++ b/tests/unit/test_content_manager.php
@@ -34,7 +34,7 @@ class test_content_manager extends SimpletestUnitBase
         $file = $this->content_manager->grab_file('http://eol.org/assets/v2/icon_taxon.png', 'image');
         $cache_path = ContentManager::cache_path($file);
         $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'.png'), 'Should upload the image');
-        $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'_orig.jpg'), 'Should be an orignial size converted to jpeg');
+        $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'_orig.jpg'), 'Should be an original size converted to jpeg');
         $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'_580_360.jpg'), 'Should create thumbnail');
         $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'_260_190.jpg'), 'Should create thumbnail');
         $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'_98_68.jpg'), 'Should create thumbnail');
@@ -70,6 +70,14 @@ class test_content_manager extends SimpletestUnitBase
         $file = $this->content_manager->grab_file('http://people.sc.fsu.edu/~jburkardt/data/wav/thermo.wav', 'audio');
         $cache_path = ContentManager::cache_path($file);
         $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'.wav'), 'Should be an wav file');
+        if (defined('SOX_BIN_PATH')) {
+            $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'_orig.png'), 'Should be a spectrogram of the audio, ');
+            $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'_580_360.png'), 'Should create thumbnail');
+            $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'_260_190.png'), 'Should create thumbnail');
+            $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'_98_68.png'), 'Should create thumbnail');
+            $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'_130_130.png'), 'Should create thumbnail');
+            $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'_88_88.png'), 'Should create thumbnail');
+        }
         self::delete_content(CONTENT_LOCAL_PATH . $cache_path);
     }
 


### PR DESCRIPTION
This code produce audio spectrogram thumbnails by default for imported audio files. It will only provide this extra functionality once EoL installs SoX on the server, and defines 'SOX_BIN_PATH' in config/environment.php in the same way as the ImageMagick utility "convert". SoX version > 14.3.2 is required for the raw spectrogram generation, as well as the appropriate libraries to allow SoX to read mp3, ogg, etc files.