### PR TITLE
A few minor corrections to the unit testing framework.

### DIFF
--- a/config/boot.php
+++ b/config/boot.php
@@ -104,7 +104,7 @@ function environment_defined($environment_name)
 {
     if(!file_exists(DOC_ROOT . 'config/database.yml'))
     {
-        // trigger_error('Booting failure: /config/database.yml does\'t exit', E_USER_ERROR);
+        // trigger_error('Booting failure: /config/database.yml doesn\'t exist', E_USER_ERROR);
         return false;
     }
     $environments = Spyc::YAMLLoad(DOC_ROOT . 'config/database.yml');
@@ -115,7 +115,7 @@ function environment_defined($environment_name)
         return true;
     }
     
-    // trigger_error('Booting failure: environment `'. $environment .'` doesn\'t exit', E_USER_ERROR);
+    // trigger_error('Booting failure: environment `'. $environment .'` doesn\'t exist', E_USER_ERROR);
     return false;
 }
 
@@ -123,7 +123,7 @@ function load_mysql_environment($environment = NULL)
 {
     if(!file_exists(DOC_ROOT . 'config/database.yml'))
     {
-        trigger_error('Booting failure: /config/database.yml does\'t exit', E_USER_ERROR);
+        trigger_error('Booting failure: /config/database.yml doesn\'t exist', E_USER_ERROR);
         return false;
     }
     $environments = Spyc::YAMLLoad(DOC_ROOT . 'config/database.yml');
@@ -131,7 +131,7 @@ function load_mysql_environment($environment = NULL)
     $possible_environments = array_keys($environments);
     if(!in_array($environment, $possible_environments))
     {
-        trigger_error('Booting failure: environment `'. $environment .'` doesn\'t exit', E_USER_ERROR);
+        trigger_error('Booting failure: environment `'. $environment .'` doesn\'t exist', E_USER_ERROR);
         return false;
     }
     

--- a/vendor/simpletest/compatibility.php
+++ b/vendor/simpletest/compatibility.php
@@ -134,7 +134,7 @@ class SimpleTestCompatibility {
      *    @access public
      *    @static
      */
-    function isA($object, $class) {
+    static function isA($object, $class) {
         if (version_compare(phpversion(), '5') >= 0) {
             if (! class_exists($class, false)) {
                 if (function_exists('interface_exists')) {

--- a/vendor/simpletest/simpletest.php
+++ b/vendor/simpletest/simpletest.php
@@ -217,7 +217,7 @@ class SimpleTest {
      *    @access public
      *    @static
      */
-    function &getContext() {
+    static function &getContext() {
         static $context = false;
         if (! $context) {
             $context = new SimpleTestContext();


### PR DESCRIPTION
I _think_ that the function isA() and  function &getContext() should be declared statically (at least this stops php throwing errors when I try to unit test). Other corrections are simply spelling
