### PR TITLE
Correct sign bug in lat/long calculations for WikimediaPages

### DIFF
--- a/tests/unit/test_connector_wikimedia.php
+++ b/tests/unit/test_connector_wikimedia.php
@@ -76,7 +76,7 @@ XML;
 |permission={{User:Flickr upload bot/upload|date=13:56, 21 September 2007 (UTC)|reviewer=Dongio}}
 {{cc-by-2.0}}
 }}
-{{Location|36|7|57.8634|N|5|20|55.9962|E}}
+{{Location|36|7|57.8634|N|5|20|55.9962|W}}
 
 [[Category:Macaca sylvanus]]";
 

--- a/vendor/wikipedia/WikimediaPage.php
+++ b/vendor/wikipedia/WikimediaPage.php
@@ -699,7 +699,7 @@ class WikimediaPage
                 $this->georef["latitude"] = $location[1] + ((($location[2] * 60) + ($location[3])) / 3600);
                 if(stripos($location[4], "N") === false) $this->georef["latitude"] *= -1;
                 $this->georef["longitude"] = $location[5] + ((($location[6] * 60) + ($location[7])) / 3600);
-                if(stripos($location[8], "W") === false) $this->georef["longitude"] *= -1;
+                if(stripos($location[8], "W") === true) $this->georef["longitude"] *= -1;
                 if(isset($location[9]))
                 {
                     $this->location = $location[9];


### PR DESCRIPTION
Sorry about this - my previous code had a bug which switched signs for East & West DMS calculations. This is  a trivial fix