### PR TITLE
Change URL

### DIFF
--- a/vendor/wikipedia/WikimediaHarvester.php
+++ b/vendor/wikipedia/WikimediaHarvester.php
@@ -500,7 +500,7 @@ class WikimediaHarvester
     private static function get_all_child_categories($base_category, $depth = null)
     {
         $sites = array( "toolserver" => "http://toolserver.org/~daniel/WikiSense/CategoryIntersect.php?wikifam=commons.wikimedia.org&basedeep=100&mode=cl&go=Scan&format=csv&userlang=en&basecat=",
-                        "wmflabs" => "http://tools.wmflabs.org/catscan2/quick_intersection.php?lang=commons&project=wikimedia&ns=14&depth=-1&max=30000&start=0&format=json&sparse=1&cats=");
+                        "wmflabs" => "http://tools.wmflabs.org/quick-intersection/index.php?lang=commons&project=wikimedia&ns=14&depth=-1&max=30000&start=0&format=json&sparse=1&cats=");
         $cats = array($base_category => 1);
         // Using toolserver.org seems to only return max ~x500 categories, so its use has been commented out below
 /*        if(count($cats) <= 1)


### PR DESCRIPTION
The url for catscan2 has changed, and the old URL is redirected using a
meta refresh redirects. Unfortunately get_remote_file() does not follow
such redirects, so we need to change the url by hand.

Perhaps we might want to adjust get_remote_file() in /lib/Functions.php to follow these redirects, as this could cause problems for other harvested urls. See http://stackoverflow.com/questions/1820705/php-can-curl-follow-meta-redirects and http://stackoverflow.com/questions/1370025/regex-for-http-equiv-refresh-meta-tag. It's all a bit yucky though.