### PR TITLE
Audio spectrogram thumbnails2

### DIFF
--- a/lib/ContentManager.php
+++ b/lib/ContentManager.php
@@ -88,6 +88,7 @@ class ContentManager
         
         // create thumbnails of website content and agent logos
         if    ($type==="image")   $this->create_local_files_and_thumbnails($cache_file_path, $permanent_prefix, $options);
+        elseif($type==="audio")   $this->create_audio_thumbnails($cache_file_path, $permanent_prefix, $options);
         elseif($type==="partner") $this->create_agent_thumbnails($cache_file_path, $permanent_prefix);
         elseif($type==="dataset")
         {
@@ -601,6 +602,78 @@ class ContentManager
         $new_image_path = $prefix . '_' . $dimensions[0] . '_' . $dimensions[1] . '.jpg';
         shell_exec($command . ' ' . escapeshellarg($new_image_path));
         self::create_checksum($new_image_path);
+    }
+
+    function create_audio_thumbnails($audiofile, $prefix, $options = array())
+    {
+        /* Some audio, video, etc files may have thumbnails created from the harvesting site (code in DataObjects.php).
+        This could be a picture, a spectrogram, or whatever. Here we create a default thumbnail set for audio files. 
+        Those that already have a thumbnail will thus have 2 potential sets of thumbnails. The "default" ones created
+         here are guaranteed to have the same prefix as the audio (.wav, .mp3 etc) file, but are .png files */
+
+        //Create "XXX_orig.png" spectrogram, whose width varies with length of sound file (with maximum length constraint)
+        $truncate_after_seconds = 60;
+        $pixels_per_second = 100;
+        $dimensions = array($pixels_per_second, self::large_image_dimensions()[1]);
+        $this->create_spectrogram($audiofile, $dimensions, $prefix, $truncate_after_seconds, true, "orig", false);
+
+        //Fixed width spectrogram thumbnails, omit axes for smaller sizes 
+        $truncate_after_seconds = 30;
+        $this->create_spectrogram($audiofile, self::large_image_dimensions(), $prefix, $truncate_after_seconds, true);
+        $this->create_spectrogram($audiofile, self::medium_image_dimensions(), $prefix, $truncate_after_seconds, true);
+        $this->create_spectrogram($audiofile, self::small_image_dimensions(), $prefix, $truncate_after_seconds, false);
+        $this->create_spectrogram($audiofile, self::large_square_dimensions(), $prefix, $truncate_after_seconds, false);
+        $this->create_spectrogram($audiofile, self::small_square_dimensions(), $prefix, $truncate_after_seconds, false);
+    }
+
+    function create_spectrogram($audiofile, $dimensions, $prefix, $max_seconds, $show_axes, $suffix=null, $fixed_width=true)
+    {
+        if (defined('SOX_BIN_PATH')) {
+            if (is_null($suffix))
+                $suffix = implode($dimensions, '_');
+            $spectrogram_path = $prefix."_".$suffix.".png";
+
+            // by trial and error, axis labels etc in SoX spectrograms seem to take 144 px in the X direction and 78 in the Y
+            $axis_decoration_px = array(144, 78);
+            $x = $dimensions[0];
+            $y = $dimensions[1];
+            //limit max dB, force white background, simple colour scheme, etc. see http://sox.sourceforge.net/sox.html
+            $sox_options = "--null remix - trim 0 $max_seconds norm spectrogram -z 50 -p 1 -l  -c ''";
+            if ($show_axes) {
+                $y -= $axis_decoration_px[1];
+                if ($fixed_width)
+                    $x -= $axis_decoration_px[0];
+            } else {
+                $sox_options .= " -r";
+            }
+            
+            if ($fixed_width)
+            {
+                //SoX only accepts x > 100px: if less, make a larger image and post-process to resize it down. 
+                if ($x < 100)
+                {
+                    $x = 100;
+                    $post_processing = CONVERT_BIN_PATH." ".escapeshellarg($spectrogram_path)." -resize ".$dimensions[0]."x".$dimensions[1]."! ".escapeshellarg($spectrogram_path);
+                }
+                $sox_options .= " -x $x -y $y";
+            } else {
+                //if not fixed_width, first element of $dimensions gives pixels per second
+                $sox_options .= " -X $x -y $y";
+            }
+
+            $command = SOX_BIN_PATH." -V0 ".escapeshellarg($audiofile)." $sox_options";
+            shell_exec($command." -o ".escapeshellarg($spectrogram_path));
+            //if sox does not exist, or cannot create the spectrograph, the spectrogram file should not exist
+            if (file_exists($spectrogram_path)) {
+                if (isset($post_processing))
+                    shell_exec($post_processing);
+                self::create_checksum($spectrogram_path);
+                return $spectrogram_path;
+            } else {
+                trigger_error("ContentManager: SoX could not produce thumbnail spectrogram for audio file $audiofile", E_USER_NOTICE);
+            }
+        }
+        return null;
     }
 
     function new_content_file_name()

--- a/lib/ContentManager.php
+++ b/lib/ContentManager.php
@@ -614,7 +614,7 @@ class ContentManager
         //Create "XXX_orig.png" spectrogram, whose width varies with length of sound file (with maximum length constraint)
         $truncate_after_seconds = 60;
         $pixels_per_second = 100;
-        $dimensions = array($pixels_per_second, self::large_image_dimensions()[1]);
+        $dimensions = array($pixels_per_second) + self::large_image_dimensions(); //overwrite $dimension[0] (width)
         $this->create_spectrogram($audiofile, $dimensions, $prefix, $truncate_after_seconds, true, "orig", false);
 
         //Fixed width spectrogram thumbnails, omit axes for smaller sizes 

--- a/tests/unit/test_content_manager.php
+++ b/tests/unit/test_content_manager.php
@@ -148,6 +148,14 @@ class test_content_manager extends SimpletestUnitBase
         $cache_num = $this->content_manager->grab_file('http://www.nch.com.au/acm/8kmp38.wav', 'audio');
         $cache_path = CONTENT_LOCAL_PATH . ContentManager::cache_num2path($cache_num);
         $this->assertTrue(file_exists($cache_path .'.wav'), 'Should be a wav file');
+        if (defined('SOX_BIN_PATH')) {
+            $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'_orig.png'), 'Should be a spectrogram of the audio, ');
+            $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'_580_360.png'), 'Should create thumbnail');
+            $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'_260_190.png'), 'Should create thumbnail');
+            $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'_98_68.png'), 'Should create thumbnail');
+            $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'_130_130.png'), 'Should create thumbnail');
+            $this->assertTrue(file_exists(CONTENT_LOCAL_PATH . $cache_path .'_88_88.png'), 'Should create thumbnail');
+        }
         self::delete_content($cache_path);
     }
 


### PR DESCRIPTION
This code produce audio spectrogram thumbnails by default for imported audio files. It will only provide this extra functionality once EoL installs SoX on the server, and defines 'SOX_BIN_PATH' in config/environment.php in the same way as the ImageMagick utility "convert". SoX version > 14.3.2 is required for the raw spectrogram generation, as well as the appropriate libraries to allow SoX to read mp3, ogg, etc files.